### PR TITLE
write header if not chunking files

### DIFF
--- a/src/mode_cis/cis_main.cpp
+++ b/src/mode_cis/cis_main.cpp
@@ -160,7 +160,7 @@ void cis_main(vector < string > & argv) {
 	//--------------
 	if (D.options.count("chunk")) {
 		vector < int > nChunk = D.options["chunk"].as < vector < int > > ();
-		if (nChunk[0] == 0) {
+		if (nChunk[0] == 0 || nChunk.size() !=  2) {
 			D.writeHeader(outFile);
 			return;
 		} else {


### PR DESCRIPTION
If there is no chunking happening, the header line should be written by default (or at least controlled via a flag). It feels strange to run `QTLtools ... --chunk 0 <any number>` just to get the header